### PR TITLE
Update parseImage.ts

### DIFF
--- a/src/utils/parseImage.ts
+++ b/src/utils/parseImage.ts
@@ -54,7 +54,8 @@ export async function parseImage(
     )
   if (node.tag === 'img') {
     const src = node.props.src
-    if (src.startsWith('/')) node.props.src = `${assetsUrl + parsePath(src)}`
+    const isPath = typeof src === 'string' && src.startsWith('/')
+    if (isPath) node.props.src = `${assetsUrl + parsePath(src)}`
   }
 
   return node


### PR DESCRIPTION
## Context

[Back in Feb 2024 I was able to use arraybuffer a image src](https://github.com/vikiival/uniframe/blob/26efc4379952ff37cc72fa458f10786de0db8210/frames/src/routes/genart.tsx#L96)

Now I am getting this fancy error

```js
TypeError: src.startsWith is not a function at parseImage
```

## Fix

Skip `src.startsWith` when it is not a string